### PR TITLE
fix: only accept nullable strings when building items for an itemlist

### DIFF
--- a/example/lib/utils/example_profile_data.dart
+++ b/example/lib/utils/example_profile_data.dart
@@ -17,7 +17,7 @@ class ExampleProfileData extends ProfileData {
   String? remarks;
 
   @override
-  Map<String, dynamic> mapWidget(
+  Map<String, Widget?> mapWidget(
     VoidCallback update,
     BuildContext context,
   ) {
@@ -38,7 +38,7 @@ class ExampleProfileData extends ProfileData {
   }
 
   @override
-  Map<String, dynamic> toMap() {
+  Map<String, String?> toMap() {
     return {'email': email, 'about': about, 'remarks': remarks};
   }
 

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -76,9 +76,9 @@ abstract class ProfileData {
 
   ProfileData fromMap(Map<String, dynamic> data);
 
-  Map<String, dynamic> toMap();
+  Map<String, String?> toMap();
 
-  Map<String, dynamic> mapWidget(VoidCallback update, BuildContext context);
+  Map<String, Widget?> mapWidget(VoidCallback update, BuildContext context);
 
   ProfileData create();
 }

--- a/lib/src/widgets/item_builder/item_builder.dart
+++ b/lib/src/widgets/item_builder/item_builder.dart
@@ -21,8 +21,8 @@ class ItemBuilder {
     String key,
     String? value,
     Widget? widget,
-    Function(String) updateItem,
-    Function(String?) saveItem,
+    void Function(String) updateItem,
+    void Function(String?) saveItem,
   ) {
     if (widget == null) {
       var controller = TextEditingController(
@@ -55,7 +55,7 @@ class ItemBuilder {
   Widget buildPassword(
     String key,
     TextEditingController controller,
-    Function(String?) onChanged,
+    void Function(String?) onChanged,
     String? Function(String?) validator,
   ) {
     var inputDecoration =

--- a/lib/src/widgets/item_builder/item_list.dart
+++ b/lib/src/widgets/item_builder/item_list.dart
@@ -16,49 +16,39 @@ class ItemList {
     this.itemBuilder,
     this.itemBuilderOptions,
   }) {
-    for (var item in items.entries) {
-      widgets.addAll({
-        item.key: itemBuilder == null
-            ? builder.build(
-                item.key,
-                item.value,
-                typeMap[item.key],
-                (value) {
-                  saveProfile();
-                },
-                (value) {
-                  updateProfile(item.key, value);
-                },
-              )
-            : itemBuilder!.build(
-                item.key,
-                item.value,
-                typeMap[item.key],
-                (value) {
-                  saveProfile();
-                },
-                (value) {
-                  updateProfile(item.key, value);
-                },
-              ),
-      });
-    }
+    var itemBuilder = this.itemBuilder ?? builder;
+
+    widgets = {
+      for (var item in items.entries) ...{
+        item.key: itemBuilder.build(
+          item.key,
+          item.value,
+          typeMap[item.key],
+          (value) {
+            saveProfile();
+          },
+          (value) {
+            updateProfile(item.key, value);
+          },
+        ),
+      },
+    };
   }
 
   /// Gets the map of item keys and their corresponding widgets.
   Map<String, Widget> getItemList() => widgets;
 
   /// Map containing item keys and their values.
-  final Map<String, dynamic> items;
+  final Map<String, String?> items;
 
   /// Map containing item keys and their types.
-  final Map<String, dynamic> typeMap;
+  final Map<String, Widget?> typeMap;
 
   /// Function to update the profile with a specific item's value.
-  final Function(String, String?) updateProfile;
+  final void Function(String, String?) updateProfile;
 
   /// Function to save the profile after an item value is updated.
-  final Function() saveProfile;
+  final void Function() saveProfile;
 
   /// Builder for custom item widgets.
   final ItemBuilder? itemBuilder;
@@ -70,7 +60,7 @@ class ItemList {
   final GlobalKey<FormState> formKey;
 
   /// Map containing item keys and their corresponding widgets.
-  Map<String, Widget> widgets = {};
+  late final Map<String, Widget> widgets;
 
   /// `builder` is an instance of `ItemBuilder` which is used
   /// to build the items in the list.

--- a/test/test_classes/test_profile_data.dart
+++ b/test/test_classes/test_profile_data.dart
@@ -13,7 +13,7 @@ class TestProfileData extends ProfileData {
   String? email;
 
   @override
-  Map<String, dynamic> mapWidget(
+  Map<String, Widget?> mapWidget(
     VoidCallback update,
     BuildContext context,
   ) =>
@@ -27,7 +27,7 @@ class TestProfileData extends ProfileData {
       );
 
   @override
-  Map<String, dynamic> toMap() => {
+  Map<String, String?> toMap() => {
         'email': email,
       };
 


### PR DESCRIPTION
The value is put directly in a TextEditingController so it needs to be a string, any other value has to be parsed to a string by the user first.